### PR TITLE
Fix onnx.load_model after onnx 1.15.0

### DIFF
--- a/onnx_modifier.py
+++ b/onnx_modifier.py
@@ -32,7 +32,7 @@ class onnxModifier:
         # https://leimao.github.io/blog/ONNX-IO-Stream/
         print("loading model...")
         stream.seek(0)
-        model_proto = onnx.load_model(stream, onnx.ModelProto, load_external_data=False)
+        model_proto = onnx.load_model(stream, "protobuf", load_external_data=False)
         print("load done!")
         return cls(name, model_proto)
 


### PR DESCRIPTION
`format` argument in [onnx.load_model](https://onnx.ai/onnx/api/serialization.html#load-a-model) is not used until version `1.15.0`, and the `format` must be a string registered into supported format.